### PR TITLE
Fix issues where query was being cached, moved modifications up to....

### DIFF
--- a/src/EFCore.OpenEdge/EFCore.OpenEdge.csproj
+++ b/src/EFCore.OpenEdge/EFCore.OpenEdge.csproj
@@ -21,8 +21,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.3</Version>
-    <PackageReleaseNotes>Fix issue with parameters in SELECT list</PackageReleaseNotes>
+    <Version>1.0.4</Version>
+    <PackageReleaseNotes>Fix issues where query was being cached, moved modifications up to the model generator so that the actual query would differ and not be cached.</PackageReleaseNotes>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/EFCore.OpenEdge/Extensions/OpenEdgeServiceCollectionExtensions.cs
+++ b/src/EFCore.OpenEdge/Extensions/OpenEdgeServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using EntityFrameworkCore.OpenEdge.Infrastructure.Internal;
 using EntityFrameworkCore.OpenEdge.Metadata.Conventions.Internal;
 using EntityFrameworkCore.OpenEdge.Query.ExpressionTranslators.Internal;
+using EntityFrameworkCore.OpenEdge.Query.Internal;
 using EntityFrameworkCore.OpenEdge.Query.Sql.Internal;
 using EntityFrameworkCore.OpenEdge.Storage;
 using EntityFrameworkCore.OpenEdge.Storage.Internal;
@@ -9,7 +10,9 @@ using EntityFrameworkCore.OpenEdge.Update;
 using EntityFrameworkCore.OpenEdge.Update.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Update;
@@ -31,6 +34,8 @@ namespace EntityFrameworkCore.OpenEdge.Extensions
                 .TryAdd<ISingletonUpdateSqlGenerator, OpenEdgeUpdateSqlGenerator>()
                 .TryAdd<IModificationCommandBatchFactory, OpenEdgeModificationCommandBatchFactory>()
                 .TryAdd<IRelationalConnection>(p => p.GetService<IOpenEdgeRelationalConnection>())
+                .TryAdd<IRelationalResultOperatorHandler, OpenEdgeResultOperatorHandler>()
+                .TryAdd<IQueryModelGenerator, OpenEdgeQueryModelGenerator>()
 
                 .TryAdd<IBatchExecutor, BatchExecutor>()
 

--- a/src/EFCore.OpenEdge/Query/Internal/OpenEdgeQueryModelGenerator.cs
+++ b/src/EFCore.OpenEdge/Query/Internal/OpenEdgeQueryModelGenerator.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq.Expressions;
+using EntityFrameworkCore.OpenEdge.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
+
+namespace EntityFrameworkCore.OpenEdge.Query.Internal
+{
+    public class OpenEdgeQueryModelGenerator : QueryModelGenerator
+    {
+        private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
+        private readonly ICurrentDbContext _currentDbContext;
+
+        public OpenEdgeQueryModelGenerator(INodeTypeProviderFactory nodeTypeProviderFactory,
+            IEvaluatableExpressionFilter evaluatableExpressionFilter,
+            ICurrentDbContext currentDbContext)
+            : base(nodeTypeProviderFactory, evaluatableExpressionFilter, currentDbContext)
+        {
+            _evaluatableExpressionFilter = evaluatableExpressionFilter;
+            _currentDbContext = currentDbContext;
+        }
+
+        public override Expression ExtractParameters(IDiagnosticsLogger<DbLoggerCategory.Query> logger, Expression query, IParameterValues parameterValues,
+            bool parameterize = true, bool generateContextAccessors = false)
+        {
+            return new OpenEdgeParameterExtractingExpressionVisitor(_evaluatableExpressionFilter, parameterValues, logger,
+                _currentDbContext.Context,
+                parameterize, generateContextAccessors).ExtractParameters(query);
+        }
+    }
+}

--- a/src/EFCore.OpenEdge/Query/Internal/OpenEdgeResultOperatorHandler.cs
+++ b/src/EFCore.OpenEdge/Query/Internal/OpenEdgeResultOperatorHandler.cs
@@ -1,0 +1,21 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace EntityFrameworkCore.OpenEdge.Query.Internal
+{
+    public class OpenEdgeResultOperatorHandler : RelationalResultOperatorHandler
+    {
+        public OpenEdgeResultOperatorHandler(IModel model, 
+            ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory, 
+            ISelectExpressionFactory selectExpressionFactory, 
+            IResultOperatorHandler resultOperatorHandler) 
+            : base(model, sqlTranslatingExpressionVisitorFactory,
+                  selectExpressionFactory, resultOperatorHandler)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fix issues where query was being cached, moved modifications up to the model generator so that the actual query would differ and not be cached.