### PR TITLE
Support DateTime Constant

### DIFF
--- a/src/EFCore.OpenEdge/Query/Sql/Internal/OpenEdgeSqlGenerator.cs
+++ b/src/EFCore.OpenEdge/Query/Sql/Internal/OpenEdgeSqlGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using EntityFrameworkCore.OpenEdge.Extensions;
@@ -15,7 +16,7 @@ namespace EntityFrameworkCore.OpenEdge.Query.Sql.Internal
             : base(dependencies, selectExpression)
         {
         }
-        
+
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
         {
             var parameterName = SqlGenerator.GenerateParameterName(parameterExpression.Name);
@@ -92,6 +93,20 @@ namespace EntityFrameworkCore.OpenEdge.Query.Sql.Internal
 
                 Sql.Append(" ");
             }
+        }
+
+        protected override Expression VisitConstant(ConstantExpression constantExpression)
+        {
+            if ((constantExpression.Type == typeof(DateTime) || constantExpression.Type == typeof(DateTime?))
+                && constantExpression.Value != null)
+            {
+                var dateTime = (DateTime)constantExpression.Value;
+                Sql.Append($"{{ ts '{dateTime:yyyy-MM-dd HH:mm:ss}' }}");
+            }
+            else
+                base.VisitConstant(constantExpression);
+            
+            return constantExpression;
         }
     }
 }


### PR DESCRIPTION
Uses the OpenEdge SQL syntax for timestamp literals `{ ts '2021-01-01 00:00:00' }` instead of the `TIMESTAMP` function which is not supported by OpenEdge.

This is documented here: [OpenEdge SQL Reference: Timestamp literals](https://docs.progress.com/de-DE/bundle/openedge-sql-reference-117/page/Timestamp-literals.html)

I have tested Date and DateTime fields mapped to `DateTime` and `DateTime?`. Progress version was 11.3.

Solves #15 